### PR TITLE
adhoc sql support

### DIFF
--- a/mssqlPipe.cpp
+++ b/mssqlPipe.cpp
@@ -956,7 +956,7 @@ HRESULT RunRestore(VirtualDevice& vd, params p, HANDLE hFile)
 		return hr;
 	}
 	
-	auto sql = BuildRestoreCommand(p, dataPath, logPath, fileList);
+	auto sql = p.sql.empty() ? BuildRestoreCommand(p, dataPath, logPath, fileList) : p.sql;
 
 	hr = RunRestoreDatabase(vd, p, sql, inputFile, false);
 	
@@ -976,11 +976,16 @@ HRESULT RunBackup(VirtualDevice& vd, params p, HANDLE hFile)
 	std::string connectionString = MakeConnectionString(p.instance, p.username, p.password);
 
 	std::string sql;
+	if (p.sql.empty())
 	{
 		std::ostringstream o;
 		// always do copy_only, could be an option in the future
 		o << "backup database [" << escape(p.database) << "] to virtual_device=N'" << escape(p.device) << "' with copy_only;";
 		sql = o.str();
+	}
+	else
+	{
+		sql = p.sql;
 	}
 
 	{

--- a/mssqlPipe.sln
+++ b/mssqlPipe.sln
@@ -1,22 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mssqlPipe", "mssqlPipe.vcxproj", "{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Debug|Win32.ActiveCfg = Debug|Win32
 		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Debug|Win32.Build.0 = Debug|Win32
+		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Debug|x64.ActiveCfg = Debug|x64
+		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Debug|x64.Build.0 = Debug|x64
 		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Release|Win32.ActiveCfg = Release|Win32
 		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Release|Win32.Build.0 = Release|Win32
+		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Release|x64.ActiveCfg = Release|x64
+		{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5D8E098D-14DC-4CDE-92D7-0683CCDE1A6F}
 	EndGlobalSection
 EndGlobal

--- a/mssqlPipe.vcxproj
+++ b/mssqlPipe.vcxproj
@@ -1,31 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9AFE0B9C-D45B-4DBA-BD4E-DA3D40BC82DD}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>mssqlPipe</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -35,21 +57,56 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(IncludePath);$(ProjectDir)</IncludePath>
+    <OutDir>bin\$(Platform)\$(Configuration)</OutDir>
+    <IntDir>bin\$(Platform)\$(Configuration)\obj</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(IncludePath);$(ProjectDir)</IncludePath>
+    <OutDir>bin\$(Platform)\$(Configuration)</OutDir>
+    <IntDir>bin\$(Platform)\$(Configuration)\obj</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(IncludePath);$(ProjectDir)</IncludePath>
+    <OutDir>bin\$(Platform)\$(Configuration)</OutDir>
+    <IntDir>bin\$(Platform)\$(Configuration)\obj</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath);$(ProjectDir)</IncludePath>
+    <OutDir>bin\$(Platform)\$(Configuration)</OutDir>
+    <IntDir>bin\$(Platform)\$(Configuration)\obj</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -63,7 +120,24 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -93,6 +167,7 @@
     <ClInclude Include="nowide\stackstring.hpp" />
     <ClInclude Include="nowide\system.hpp" />
     <ClInclude Include="nowide\utf.hpp" />
+    <ClInclude Include="nowide\utf8_codecvt.hpp" />
     <ClInclude Include="nowide\windows.hpp" />
     <ClInclude Include="params.h" />
     <ClInclude Include="pipestat.h" />
@@ -108,7 +183,9 @@
     <ClCompile Include="params.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/mssqlPipe.vcxproj.filters
+++ b/mssqlPipe.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClInclude Include="nowide\windows.hpp">
       <Filter>nowide</Filter>
     </ClInclude>
+    <ClInclude Include="nowide\utf8_codecvt.hpp">
+      <Filter>nowide</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">

--- a/nowide/convert.hpp
+++ b/nowide/convert.hpp
@@ -14,13 +14,13 @@
 
 namespace nowide {
     ///
-    /// \brief Template function that converts a buffer of UTF sequence in range [source_begin,source_end)
+    /// \brief Template function that converts a buffer of UTF sequences in range [source_begin,source_end)
     /// to the output \a buffer of size \a buffer_size.
     ///
-    /// In case of success a NUL terminated string returned (buffer), otherwise 0 is returned.
+    /// In case of success a NULL terminated string is returned (buffer), otherwise 0 is returned.
     ///
-    /// If there is not enough room in the buffer or the source sequence contains invalid UTF
-    /// 0 is returned, and the contend of the buffer is undefined.
+    /// If there is not enough room in the buffer or the source sequence contains invalid UTF,
+    /// 0 is returned, and the contents of the buffer are undefined.
     ///
     template<typename CharOut,typename CharIn>
     CharOut *basic_convert(CharOut *buffer,size_t buffer_size,CharIn const *source_begin,CharIn const *source_end)
@@ -64,10 +64,10 @@ namespace nowide {
     /// \endcond
 
     ///
-    /// Convert NUL terminated UTF source string to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert NULL terminated UTF source string to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline char *narrow(char *output,size_t output_size,wchar_t const *source)
@@ -75,10 +75,10 @@ namespace nowide {
         return basic_convert(output,output_size,source,details::basic_strend(source));
     }
     ///
-    /// Convert UTF text in range [begin,end) to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert UTF text in range [begin,end) to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline char *narrow(char *output,size_t output_size,wchar_t const *begin,wchar_t const *end)
@@ -86,10 +86,10 @@ namespace nowide {
         return basic_convert(output,output_size,begin,end);
     }
     ///
-    /// Convert NUL terminated UTF source string to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert NULL terminated UTF source string to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline wchar_t *widen(wchar_t *output,size_t output_size,char const *source)
@@ -97,10 +97,10 @@ namespace nowide {
         return basic_convert(output,output_size,source,details::basic_strend(source));
     }
     ///
-    /// Convert UTF text in range [begin,end) to NUL terminated \a output string of size at
-    /// most output_size (including NUL)
+    /// Convert UTF text in range [begin,end) to NULL terminated \a output string of size at
+    /// most output_size (including NULL)
     /// 
-    /// In case of surcess output is returned, if the input sequence is illegal,
+    /// In case of success output is returned, if the input sequence is illegal,
     /// or there is not enough room NULL is returned 
     ///
     inline wchar_t *widen(wchar_t *output,size_t output_size,char const *begin,char const *end)
@@ -118,15 +118,6 @@ namespace nowide {
     {
         return nowide::conv::utf_to_utf<char>(s);
     }
-	///
-	/// Convert between Wide - UTF-16/32 string and UTF-8 string.
-	///
-	/// nowide::conv::conversion_error is thrown in a case of a error
-	///
-	inline std::string narrow(wchar_t const *s, size_t input_count)
-	{
-		return nowide::conv::utf_to_utf<char>(s, s+input_count);
-	}
     ///
     /// Convert between UTF-8 and UTF-16 string, implemented only on Windows platform
     ///
@@ -136,15 +127,6 @@ namespace nowide {
     {
         return nowide::conv::utf_to_utf<wchar_t>(s);
     }
-	///
-	/// Convert between UTF-8 and UTF-16 string, implemented only on Windows platform
-	///
-	/// nowide::conv::conversion_error is thrown in a case of a error
-	///
-	inline std::wstring widen(char const *s, size_t input_count)
-	{
-		return nowide::conv::utf_to_utf<wchar_t>(s, s+input_count);
-	}
     ///
     /// Convert between Wide - UTF-16/32 string and UTF-8 string
     ///

--- a/nowide/cstdio.hpp
+++ b/nowide/cstdio.hpp
@@ -33,7 +33,7 @@ namespace nowide {
 ///
 /// \brief Same as freopen but file_name and mode are UTF-8 strings
 ///
-/// In invalid UTF-8 given, NULL is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, NULL is returned and errno is set to EINVAL
 ///
 inline FILE *freopen(char const *file_name,char const *mode,FILE *stream)
 {
@@ -48,7 +48,7 @@ inline FILE *freopen(char const *file_name,char const *mode,FILE *stream)
 ///
 /// \brief Same as fopen but file_name and mode are UTF-8 strings
 ///
-/// In invalid UTF-8 given, NULL is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, NULL is returned and errno is set to EINVAL
 ///
 inline FILE *fopen(char const *file_name,char const *mode)
 {
@@ -63,7 +63,7 @@ inline FILE *fopen(char const *file_name,char const *mode)
 ///
 /// \brief Same as rename but old_name and new_name are UTF-8 strings
 ///
-/// In invalid UTF-8 given, -1 is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, -1 is returned and errno is set to EINVAL
 ///
 inline int rename(char const *old_name,char const *new_name)
 {
@@ -77,7 +77,7 @@ inline int rename(char const *old_name,char const *new_name)
 ///
 /// \brief Same as rename but name is UTF-8 string
 ///
-/// In invalid UTF-8 given, -1 is returned and errno is set to EINVAL
+/// If invalid UTF-8 given, -1 is returned and errno is set to EINVAL
 ///
 inline int remove(char const *name)
 {

--- a/nowide/encoding_utf.hpp
+++ b/nowide/encoding_utf.hpp
@@ -46,7 +46,7 @@ namespace nowide{
         }
 
         ///
-        /// Convert a Unicode NUL terminated string \a str other Unicode encoding
+        /// Convert a Unicode NULL terminated string \a str other Unicode encoding
         ///
         template<typename CharOut,typename CharIn>
         std::basic_string<CharOut>

--- a/nowide/filebuf.hpp
+++ b/nowide/filebuf.hpp
@@ -17,7 +17,7 @@
 
 #ifdef NOWIDE_MSVC
 #  pragma warning(push)
-#  pragma warning(disable : 4996 4244)
+#  pragma warning(disable : 4996 4244 4800)
 #endif
 
 
@@ -87,6 +87,9 @@ namespace nowide {
                 ::fclose(file_);
                 file_ = 0;
             }
+            bool ate = bool(mode & std::ios_base::ate);
+            if(ate)
+                mode = mode ^ std::ios_base::ate;
             wchar_t const *smode = get_mode(mode);
             if(!smode)
                 return 0;
@@ -100,6 +103,10 @@ namespace nowide {
             #endif
             if(!f)
                 return 0;
+            if(ate && fseek(f,0,SEEK_END)!=0) {
+                fclose(f);
+                return 0;
+            }
             file_ = f;
             return this;
         }

--- a/nowide/fstream.hpp
+++ b/nowide/fstream.hpp
@@ -57,7 +57,20 @@ namespace nowide {
             std::ios::rdbuf(buf_.get());
             open(file_name,mode);
         }
+
+        explicit basic_ifstream(std::string const &file_name,std::ios_base::openmode mode = std::ios_base::in) : 
+            internal_stream_type(0) 
+        {
+            buf_.reset(new internal_buffer_type());
+            std::ios::rdbuf(buf_.get());
+            open(file_name,mode);
+        }
+
         
+        void open(std::string const &file_name,std::ios_base::openmode mode = std::ios_base::in)
+        {
+            open(file_name.c_str(),mode);
+        }
         void open(char const *file_name,std::ios_base::openmode mode = std::ios_base::in)
         {
             if(!buf_->open(file_name,mode | std::ios_base::in)) {
@@ -120,6 +133,17 @@ namespace nowide {
             std::ios::rdbuf(buf_.get());
             open(file_name,mode);
         }
+        explicit basic_ofstream(std::string const &file_name,std::ios_base::openmode mode = std::ios_base::out) :
+            internal_stream_type(0)
+        {
+            buf_.reset(new internal_buffer_type());
+            std::ios::rdbuf(buf_.get());
+            open(file_name,mode);
+        }
+        void open(std::string const &file_name,std::ios_base::openmode mode = std::ios_base::out)
+        {
+            open(file_name.c_str(),mode);
+        }
         void open(char const *file_name,std::ios_base::openmode mode = std::ios_base::out)
         {
             if(!buf_->open(file_name,mode | std::ios_base::out)) {
@@ -181,6 +205,17 @@ namespace nowide {
             buf_.reset(new internal_buffer_type());
             std::ios::rdbuf(buf_.get());
             open(file_name,mode);
+        }
+        explicit basic_fstream(std::string const &file_name,std::ios_base::openmode mode = std::ios_base::out | std::ios_base::in) :
+            internal_stream_type(0)
+        {
+            buf_.reset(new internal_buffer_type());
+            std::ios::rdbuf(buf_.get());
+            open(file_name,mode);
+        }
+        void open(std::string const &file_name,std::ios_base::openmode mode = std::ios_base::out | std::ios_base::out)
+        {
+            open(file_name.c_str(),mode);
         }
         void open(char const *file_name,std::ios_base::openmode mode = std::ios_base::out | std::ios_base::out)
         {

--- a/nowide/iostream.cpp
+++ b/nowide/iostream.cpp
@@ -5,8 +5,6 @@
 //  accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
-#include "stdafx.h"
-
 #define NOWIDE_SOURCE
 #include <nowide/iostream.hpp>
 #include <nowide/convert.hpp>
@@ -25,16 +23,23 @@
 
 namespace nowide {
 namespace details {
+
+	namespace {
+		bool is_atty_handle(HANDLE h) 
+		{
+            if(h) {
+                DWORD dummy;
+                return GetConsoleMode(h,&dummy) == TRUE;
+            }
+			return false;
+		}
+	}
+
     class console_output_buffer : public std::streambuf {
     public:
         console_output_buffer(HANDLE h) :
-            handle_(h),
-            isatty_(false)
+            handle_(h)
         {
-            if(handle_) {
-                DWORD dummy;
-                isatty_ = GetConsoleMode(handle_,&dummy) == TRUE;
-            }
         }
     protected:
         int sync()
@@ -66,12 +71,7 @@ namespace details {
             namespace uf = nowide::utf;
             char const *b = p;
             char const *e = p+n;
-            if(!isatty_) {
-                DWORD size=0;
-                if(!WriteFile(handle_,p,n,&size,0) || static_cast<int>(size) != n)
-                    return -1;
-                return n;
-            }
+            DWORD size=0;
             if(n > buffer_size)
                 return -1;
             wchar_t *out = wbuffer_;
@@ -83,7 +83,7 @@ namespace details {
             }
             if(c==uf::illegal)
                 return -1;
-            if(!WriteConsoleW(handle_,wbuffer_,out - wbuffer_,0,0))
+            if(!WriteConsoleW(handle_,wbuffer_,out - wbuffer_,&size,0))
                 return -1;
             return decoded;
         }
@@ -92,20 +92,14 @@ namespace details {
         char buffer_[buffer_size];
         wchar_t wbuffer_[buffer_size]; // for null
         HANDLE handle_;
-        bool isatty_;
     };
     
     class console_input_buffer: public std::streambuf {
     public:
         console_input_buffer(HANDLE h) :
             handle_(h),
-            isatty_(false),
             wsize_(0)
         {
-            if(handle_) {
-                DWORD dummy;
-                isatty_ = GetConsoleMode(handle_,&dummy) == TRUE;
-            }
         } 
         
     protected:
@@ -162,12 +156,6 @@ namespace details {
         size_t read()
         {
             namespace uf = nowide::utf;
-            if(!isatty_) {
-                DWORD read_bytes = 0;
-                if(!ReadFile(handle_,buffer_,buffer_size,&read_bytes,0))
-                    return 0;
-                return read_bytes;
-            }
             DWORD read_wchars = 0;
             size_t n = wbuffer_size - wsize_;
             if(!ReadConsoleW(handle_,wbuffer_,n,&read_wchars,0))
@@ -185,7 +173,7 @@ namespace details {
             }
             
             if(c==uf::illegal)
-                return -1;
+                return 0;
             
             
             if(c==uf::incomplete) {
@@ -200,7 +188,6 @@ namespace details {
         char buffer_[buffer_size];
         wchar_t wbuffer_[buffer_size]; // for null
         HANDLE handle_;
-        bool isatty_;
         int wsize_;
         std::vector<char> pback_buffer_;
     };
@@ -216,19 +203,32 @@ namespace details {
             h = GetStdHandle(STD_ERROR_HANDLE);
             break;
         }
-        d.reset(new console_output_buffer(h));
-        std::ostream::rdbuf(d.get());
+		if(is_atty_handle(h)) {
+			d.reset(new console_output_buffer(h));
+			std::ostream::rdbuf(d.get());
+		}
+		else {
+			std::ostream::rdbuf( fd == 1 ? std::cout.rdbuf() : std::cerr.rdbuf() );
+		}
     }
-    
     winconsole_ostream::~winconsole_ostream()
     {
+		try {
+			flush();
+		}
+		catch(...){}
     }
 
     winconsole_istream::winconsole_istream() : std::istream(0)
     {
         HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
-        d.reset(new console_input_buffer(h));
-        std::istream::rdbuf(d.get());
+		if(is_atty_handle(h)) {
+			d.reset(new console_input_buffer(h));
+			std::istream::rdbuf(d.get());
+		}
+		else {
+			std::istream::rdbuf(std::cin.rdbuf());
+		}
     }
     
     winconsole_istream::~winconsole_istream()

--- a/nowide/utf8_codecvt.hpp
+++ b/nowide/utf8_codecvt.hpp
@@ -1,0 +1,499 @@
+//
+//  Copyright (c) 2015 Artyom Beilis (Tonkikh)
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef NOWIDE_UTF8_CODECVT_HPP
+#define NOWIDE_UTF8_CODECVT_HPP
+
+#include <nowide/utf.hpp>
+#include <nowide/cstdint.hpp>
+#include <nowide/static_assert.hpp>
+#include <locale>
+
+
+namespace nowide {
+
+//
+// Make sure that mbstate can keep 16 bit of UTF-16 sequence
+//
+NOWIDE_STATIC_ASSERT(sizeof(std::mbstate_t)>=2);
+
+#if defined _MSC_VER && _MSC_VER < 1700
+// MSVC do_length is non-standard it counts wide characters instead of narrow and does not change mbstate
+#define NOWIDE_DO_LENGTH_MBSTATE_CONST
+#endif
+
+template<typename CharType,int CharSize=sizeof(CharType)>
+class utf8_codecvt;
+
+template<typename CharType>
+class utf8_codecvt<CharType,2> : public std::codecvt<CharType,char,std::mbstate_t>
+{
+public:
+    utf8_codecvt(size_t refs = 0) : std::codecvt<CharType,char,std::mbstate_t>(refs)
+    {
+    }
+protected:
+
+    typedef CharType uchar;
+
+    virtual std::codecvt_base::result do_unshift(std::mbstate_t &s,char *from,char * /*to*/,char *&next) const
+    {
+        nowide::uint16_t &state = *reinterpret_cast<nowide::uint16_t *>(&s);
+#ifdef DEBUG_CODECVT            
+        std::cout << "Entering unshift " << std::hex << state << std::dec << std::endl;
+#endif            
+        if(state != 0)
+            return std::codecvt_base::error;
+        next=from;
+        return std::codecvt_base::ok;
+    }
+    virtual int do_encoding() const throw()
+    {
+        return 0;
+    }
+    virtual int do_max_length() const throw()
+    {
+        return 4;
+    }
+    virtual bool do_always_noconv() const throw()
+    {
+        return false;
+    }
+
+    virtual int
+    do_length(  std::mbstate_t 
+    #ifdef NOWIDE_DO_LENGTH_MBSTATE_CONST
+            const   
+    #endif
+            &std_state,
+            char const *from,
+            char const *from_end,
+            size_t max) const
+    {
+        #ifndef NOWIDE_DO_LENGTH_MBSTATE_CONST
+        char const *save_from = from;
+        nowide::uint16_t &state = *reinterpret_cast<nowide::uint16_t *>(&std_state);
+        #else
+        size_t save_max = max;
+        nowide::uint16_t state = *reinterpret_cast<nowide::uint16_t const *>(&std_state);
+        #endif
+        while(max > 0 && from < from_end){
+            char const *prev_from = from;
+            nowide::uint32_t ch=nowide::utf::utf_traits<char>::decode(from,from_end);
+            if(ch==nowide::utf::incomplete || ch==nowide::utf::illegal) {
+                from = prev_from;
+                break;
+            }
+            max --;
+            if(ch > 0xFFFF) {
+                if(state == 0) {
+                    from = prev_from;
+                    state = 1;
+                }
+                else {
+                    state = 0;
+                }
+            }        
+        }
+        #ifndef NOWIDE_DO_LENGTH_MBSTATE_CONST
+        return from - save_from;
+        #else
+        return save_max - max;
+        #endif
+    }
+
+    
+    virtual std::codecvt_base::result 
+    do_in(  std::mbstate_t &std_state,
+            char const *from,
+            char const *from_end,
+            char const *&from_next,
+            uchar *to,
+            uchar *to_end,
+            uchar *&to_next) const
+    {
+        std::codecvt_base::result r=std::codecvt_base::ok;
+        
+        // mbstate_t is POD type and should be initialized to 0 (i.a. state = stateT())
+        // according to standard. We use it to keep a flag 0/1 for surrogate pair writing
+        //
+        // if 0 no code above >0xFFFF observed, of 1 a code above 0xFFFF observerd
+        // and first pair is written, but no input consumed
+        nowide::uint16_t &state = *reinterpret_cast<nowide::uint16_t *>(&std_state);
+        while(to < to_end && from < from_end)
+        {
+#ifdef DEBUG_CODECVT            
+            std::cout << "Entering IN--------------" << std::endl;
+            std::cout << "State " << std::hex << state <<std::endl;
+            std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif           
+            char const *from_saved = from;
+            
+            uint32_t ch=nowide::utf::utf_traits<char>::decode(from,from_end);
+            
+            if(ch==nowide::utf::illegal) {
+                from = from_saved;
+                r=std::codecvt_base::error;
+                break;
+            }
+            if(ch==nowide::utf::incomplete) {
+                from = from_saved;
+                r=std::codecvt_base::partial;
+                break;
+            }
+            // Normal codepoints go direcly to stream
+            if(ch <= 0xFFFF) {
+                *to++=ch;
+            }
+            else {
+                // for  other codepoints we do following
+                //
+                // 1. We can't consume our input as we may find ourselfs
+                //    in state where all input consumed but not all output written,i.e. only
+                //    1st pair is written
+                // 2. We only write first pair and mark this in the state, we also revert back
+                //    the from pointer in order to make sure this codepoint would be read
+                //    once again and then we would consume our input together with writing
+                //    second surrogate pair
+                ch-=0x10000;
+                nowide::uint16_t vh = ch >> 10;
+                nowide::uint16_t vl = ch & 0x3FF;
+                nowide::uint16_t w1 = vh + 0xD800;
+                nowide::uint16_t w2 = vl + 0xDC00;
+                if(state == 0) {
+                    from = from_saved;
+                    *to++ = w1;
+                    state = 1;
+                }
+                else {
+                    *to++ = w2;
+                    state = 0;
+                }
+            }
+        }
+        from_next=from;
+        to_next=to;
+        if(r == std::codecvt_base::ok && (from!=from_end || state!=0))
+            r = std::codecvt_base::partial;
+#ifdef DEBUG_CODECVT            
+        std::cout << "Returning ";
+        switch(r) {
+        case std::codecvt_base::ok:
+            std::cout << "ok" << std::endl;
+            break;
+        case std::codecvt_base::partial:
+            std::cout << "partial" << std::endl;
+            break;
+        case std::codecvt_base::error:
+            std::cout << "error" << std::endl;
+            break;
+        default:
+            std::cout << "other" << std::endl;
+            break;
+        }
+        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif            
+        return r;
+    }
+    
+    virtual std::codecvt_base::result 
+    do_out( std::mbstate_t &std_state,
+            uchar const *from,
+            uchar const *from_end,
+            uchar const *&from_next,
+            char *to,
+            char *to_end,
+            char *&to_next) const
+    {
+        std::codecvt_base::result r=std::codecvt_base::ok;
+        // mbstate_t is POD type and should be initialized to 0 (i.a. state = stateT())
+        // according to standard. We assume that sizeof(mbstate_t) >=2 in order
+        // to be able to store first observerd surrogate pair
+        //
+        // State: state!=0 - a first surrogate pair was observerd (state = first pair),
+        // we expect the second one to come and then zero the state
+        ///
+        nowide::uint16_t &state = *reinterpret_cast<nowide::uint16_t *>(&std_state);
+        while(to < to_end && from < from_end)
+        {
+#ifdef DEBUG_CODECVT            
+        std::cout << "Entering OUT --------------" << std::endl;
+        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif            
+            nowide::uint32_t ch=0;
+            if(state != 0) {
+                // if the state idecates that 1st surrogate pair was written
+                // we should make sure that the second one that comes is actually
+                // second surrogate
+                nowide::uint16_t w1 = state;
+                nowide::uint16_t w2 = *from; 
+                // we don't forward from as writing may fail to incomplete or
+                // partial conversion
+                if(0xDC00 <= w2 && w2<=0xDFFF) {
+                    nowide::uint16_t vh = w1 - 0xD800;
+                    nowide::uint16_t vl = w2 - 0xDC00;
+                    ch=((uint32_t(vh) << 10)  | vl) + 0x10000;
+                }
+                else {
+                    // Invalid surrogate
+                    r=std::codecvt_base::error;
+                    break;
+                }
+            }
+            else {
+                ch = *from;
+                if(0xD800 <= ch && ch<=0xDBFF) {
+                    // if this is a first surrogate pair we put
+                    // it into the state and consume it, note we don't
+                    // go forward as it should be illegal so we increase
+                    // the from pointer manually
+                    state = ch;
+                    from++;
+                    continue;
+                }
+                else if(0xDC00 <= ch && ch<=0xDFFF) {
+                    // if we observe second surrogate pair and 
+                    // first only may be expected we should break from the loop with error
+                    // as it is illegal input
+                    r=std::codecvt_base::error;
+                    break;
+                }
+            }
+            if(!nowide::utf::is_valid_codepoint(ch)) {
+                r=std::codecvt_base::error;
+                break;
+            }
+            int len = nowide::utf::utf_traits<char>::width(ch);
+            if(to_end - to < len) {
+                r=std::codecvt_base::partial;
+                break;
+            }
+            to = nowide::utf::utf_traits<char>::encode(ch,to);
+            state = 0;
+            from++;
+        }
+        from_next=from;
+        to_next=to;
+        if(r==std::codecvt_base::ok && from!=from_end)
+            r = std::codecvt_base::partial;
+#ifdef DEBUG_CODECVT            
+        std::cout << "Returning ";
+        switch(r) {
+        case std::codecvt_base::ok:
+            std::cout << "ok" << std::endl;
+            break;
+        case std::codecvt_base::partial:
+            std::cout << "partial" << std::endl;
+            break;
+        case std::codecvt_base::error:
+            std::cout << "error" << std::endl;
+            break;
+        default:
+            std::cout << "other" << std::endl;
+            break;
+        }
+        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif            
+        return r;
+    }
+    
+};
+
+template<typename CharType>
+class utf8_codecvt<CharType,4> : public std::codecvt<CharType,char,std::mbstate_t>
+{
+public:
+    utf8_codecvt(size_t refs = 0) : std::codecvt<CharType,char,std::mbstate_t>(refs)
+    {
+    }
+protected:
+
+    typedef CharType uchar;
+
+    virtual std::codecvt_base::result do_unshift(std::mbstate_t &/*s*/,char *from,char * /*to*/,char *&next) const
+    {
+        next=from;
+        return std::codecvt_base::ok;
+    }
+    virtual int do_encoding() const throw()
+    {
+        return 0;
+    }
+    virtual int do_max_length() const throw()
+    {
+        return 4;
+    }
+    virtual bool do_always_noconv() const throw()
+    {
+        return false;
+    }
+
+    virtual int
+    do_length(  std::mbstate_t 
+    #ifdef NOWIDE_DO_LENGTH_MBSTATE_CONST
+            const   
+    #endif    
+            &/*state*/,
+            char const *from,
+            char const *from_end,
+            size_t max) const
+    {
+        #ifndef NOWIDE_DO_LENGTH_MBSTATE_CONST 
+        char const *start_from = from;
+        #else
+        size_t save_max = max;
+        #endif
+        
+        while(max > 0 && from < from_end){
+            char const *save_from = from;
+            nowide::uint32_t ch=nowide::utf::utf_traits<char>::decode(from,from_end);
+            if(ch==nowide::utf::incomplete || ch==nowide::utf::illegal) {
+                from = save_from;
+                break;
+            }
+            max--;
+        }
+        #ifndef NOWIDE_DO_LENGTH_MBSTATE_CONST 
+        return from - start_from;
+        #else
+        return save_max - max;
+        #endif
+    }
+
+    
+    virtual std::codecvt_base::result 
+    do_in(  std::mbstate_t &/*state*/,
+            char const *from,
+            char const *from_end,
+            char const *&from_next,
+            uchar *to,
+            uchar *to_end,
+            uchar *&to_next) const
+    {
+        std::codecvt_base::result r=std::codecvt_base::ok;
+        
+        // mbstate_t is POD type and should be initialized to 0 (i.a. state = stateT())
+        // according to standard. We use it to keep a flag 0/1 for surrogate pair writing
+        //
+        // if 0 no code above >0xFFFF observed, of 1 a code above 0xFFFF observerd
+        // and first pair is written, but no input consumed
+        while(to < to_end && from < from_end)
+        {
+#ifdef DEBUG_CODECVT            
+            std::cout << "Entering IN--------------" << std::endl;
+            std::cout << "State " << std::hex << state <<std::endl;
+            std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif           
+            char const *from_saved = from;
+            
+            uint32_t ch=nowide::utf::utf_traits<char>::decode(from,from_end);
+            
+            if(ch==nowide::utf::illegal) {
+                r=std::codecvt_base::error;
+                from = from_saved;
+                break;
+            }
+            if(ch==nowide::utf::incomplete) {
+                r=std::codecvt_base::partial;
+                from=from_saved;
+                break;
+            }
+            *to++=ch;
+        }
+        from_next=from;
+        to_next=to;
+        if(r == std::codecvt_base::ok && from!=from_end)
+            r = std::codecvt_base::partial;
+#ifdef DEBUG_CODECVT            
+        std::cout << "Returning ";
+        switch(r) {
+        case std::codecvt_base::ok:
+            std::cout << "ok" << std::endl;
+            break;
+        case std::codecvt_base::partial:
+            std::cout << "partial" << std::endl;
+            break;
+        case std::codecvt_base::error:
+            std::cout << "error" << std::endl;
+            break;
+        default:
+            std::cout << "other" << std::endl;
+            break;
+        }
+        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif            
+        return r;
+    }
+    
+    virtual std::codecvt_base::result 
+    do_out( std::mbstate_t &std_state,
+            uchar const *from,
+            uchar const *from_end,
+            uchar const *&from_next,
+            char *to,
+            char *to_end,
+            char *&to_next) const
+    {
+        std::codecvt_base::result r=std::codecvt_base::ok;
+        while(to < to_end && from < from_end)
+        {
+#ifdef DEBUG_CODECVT            
+        std::cout << "Entering OUT --------------" << std::endl;
+        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif            
+            nowide::uint32_t ch=0;
+            ch = *from;
+            if(!nowide::utf::is_valid_codepoint(ch)) {
+                r=std::codecvt_base::error;
+                break;
+            }
+            int len = nowide::utf::utf_traits<char>::width(ch);
+            if(to_end - to < len) {
+                r=std::codecvt_base::partial;
+                break;
+            }
+            to = nowide::utf::utf_traits<char>::encode(ch,to);
+            from++;
+        }
+        from_next=from;
+        to_next=to;
+        if(r==std::codecvt_base::ok && from!=from_end)
+            r = std::codecvt_base::partial;
+#ifdef DEBUG_CODECVT            
+        std::cout << "Returning ";
+        switch(r) {
+        case std::codecvt_base::ok:
+            std::cout << "ok" << std::endl;
+            break;
+        case std::codecvt_base::partial:
+            std::cout << "partial" << std::endl;
+            break;
+        case std::codecvt_base::error:
+            std::cout << "error" << std::endl;
+            break;
+        default:
+            std::cout << "other" << std::endl;
+            break;
+        }
+        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
+#endif            
+        return r;
+    }
+};
+
+} // nowide
+
+
+#endif
+///
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/params.cpp
+++ b/params.cpp
@@ -381,6 +381,14 @@ params ParseSqlParams(int argc, const char* argv[], bool quiet)
 			++arg;
 		}
 
+		// detect raw sql in place of database name
+		int placeholder = ToLower(p.database).find("{device}");
+		if (arg == argEnd && placeholder > 0) {
+			p.sql = p.database.replace(placeholder, 8, p.device);
+			p.database = "";
+			return p;
+		}
+
 		if (p.isBackup()) {
 
 			// to file

--- a/params.h
+++ b/params.h
@@ -22,6 +22,7 @@ struct params
 	std::string device;
 	std::string from;
 	std::string to;
+	std::string sql;
 
 	std::string as;
 	std::string username;

--- a/util.h
+++ b/util.h
@@ -130,7 +130,7 @@ inline std::string make_guid()
 	GUID guidRaw = { 0 };
 	::CoCreateGuid(&guidRaw);
 	::StringFromGUID2(guidRaw, guid, _countof(guid));
-	return narrow(guid, _countof(guid) - 1);
+	return narrow(guid);
 }
 
 template<typename _IIID>


### PR DESCRIPTION
instead of trying to wrap all the various options for backup and restore, just allow a backup or restore statement and replace `{device}` with the virtual device name. e.g.:

`mssqlPipe backup "backup log mydb to virtual_device='{device}' with differential, encryption algorithm=aes_128"
`

this is a lot easier to use from a SQL Agent job than using `pipe to` and a separate query, at least I couldn't figure out how to get SQL Agent to start a query after starting a command that doesn't return.